### PR TITLE
feat: support React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/src/box.tsx
+++ b/src/box.tsx
@@ -28,7 +28,7 @@ const Box = React.forwardRef(<E extends React.ElementType>({ is, children, allow
   }
 
   return React.createElement(is || 'div', parsedProps, children)
-}) as <E extends React.ElementType = 'div'>(props: BoxProps<E>) => JSX.Element
+}) as <E extends React.ElementType = 'div'>(props: BoxProps<E>) => React.JSX.Element
 
 // @ts-ignore
 Box.displayName = 'Box'

--- a/src/box.tsx
+++ b/src/box.tsx
@@ -1,11 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { BoxProps } from './types/box-types'
+import { EnhancerProps } from './types/enhancers'
 import { propTypes } from './enhancers'
 import enhanceProps from './enhance-props'
 import { extractAnchorProps, getUseSafeHref } from './utils/safeHref'
 
 const Box = React.forwardRef(<E extends React.ElementType>({ is, children, allowUnsafeHref, ...props }: BoxProps<E>, ref: React.Ref<Element>) => {
+  // React 19 removed defaultProps on function components; apply the default the
+  // same way React did (only when absent, after the user's own props)
+  const enhancerProps = props as EnhancerProps
+  if (enhancerProps.boxSizing === undefined) {
+    enhancerProps.boxSizing = 'border-box'
+  }
+
   // Convert the CSS props to class names (and inject the styles)
   const {className, enhancedProps: parsedProps} = enhanceProps(props)
 
@@ -38,12 +46,6 @@ Box.propTypes = {
   ...propTypes,
   is: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.elementType]),
   allowUnsafeHref: PropTypes.bool
-}
-
-// @ts-ignore
-Box.defaultProps = {
-  is: 'div',
-  boxSizing: 'border-box'
 }
 
 export default Box

--- a/src/types/box-types.ts
+++ b/src/types/box-types.ts
@@ -11,8 +11,8 @@ export type Without<T, K> = Pick<T, Exclude<keyof T, K>>
  * @see {@link https://github.com/emotion-js/emotion/blob/b4214b8757c7ede1db1688075251946b2082f9d1/packages/styled-base/types/helper.d.ts#L6-L8}
  */
 export type PropsOf<
-  E extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-> = JSX.LibraryManagedAttributes<E, React.ComponentPropsWithRef<E>>
+  E extends keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<any>
+> = React.JSX.LibraryManagedAttributes<E, React.ComponentPropsWithRef<E>>
 
 /**
  * Generic component props with "is" prop
@@ -48,4 +48,4 @@ export type PolymorphicBoxProps<
  */
 export type BoxComponent<P = {}, D extends React.ElementType = React.ElementType> = <E extends React.ElementType = D>(
   props: PolymorphicBoxProps<E, P>
-) => JSX.Element
+) => React.JSX.Element


### PR DESCRIPTION
## Summary
- Widen the `react` peer dependency range to include `^19.0.0`
- Replace global `JSX` namespace references with `React.JSX` — React 19's typings removed the global namespace ([upgrade guide: The JSX namespace in TypeScript](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript)), which made `BoxProps`/`BoxComponent` silently degrade to `any` for consumers on `@types/react` 19. `React.JSX` resolves on `@types/react` 18.2.21+ (the pinned devDep is 18.3.18) and 19.
- Remove `Box.defaultProps` — React 19 ignores `defaultProps` on function components ([upgrade guide: Removed propTypes and defaultProps](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops)), which silently dropped the `box-sizing: border-box` default from every `Box`. The default is now applied inline, only when the prop is absent, mirroring React's own `resolveDefaultProps` order so the emitted CSS/DOM is unchanged on React 16–18 (all 88 ava tests pass with unchanged snapshots). The `is: 'div'` default was already redundant with the `is || 'div'` fallback.

## Release
After merge: `yarn release` as 5.8.0 (publishes `@maestroqa/ui-box`; dist is rebuilt by `prepublishOnly`).