### PR TITLE
fix: revert `eslint-config-xo-typescript` to ^0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "enzyme": "3.11.0",
     "eslint": "^5.16.0",
     "eslint-config-xo-react": "^0.19.0",
-    "eslint-config-xo-typescript": "^0.11.0",
+    "eslint-config-xo-typescript": "^0.10.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.5.0",
     "husky": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5882,7 +5882,7 @@ enzyme@3.11.0:
   integrity sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==
   dependencies:
     array.prototype.flat "^1.2.3"
-    cheerio "1.0.0-rc.3"
+    cheerio "^1.0.0-rc.3"
     enzyme-shallow-equal "^1.0.1"
     function.prototype.name "^1.1.2"
     has "^1.0.3"
@@ -6179,10 +6179,10 @@ eslint-config-xo-react@^0.19.0:
   resolved "https://registry.yarnpkg.com/eslint-config-xo-react/-/eslint-config-xo-react-0.19.0.tgz#26c452c4729750935fb6b65923e222c4fd42b214"
   integrity sha512-0PizlypxrXj92rW+u39sQndo2/7B7PL3wBpZs6+wXHx4+RiBO/V2yB/rUXdwS7DGpoKPtQzTdmQquPW5+vbbZw==
 
-eslint-config-xo-typescript@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.11.0.tgz#69de7cd978d1aaee6449c79d0460b92023d399f3"
-  integrity sha512-vBI0ZuvmfMhBTQPs2Qa0d4vTodMrm/HwS/bG+vy+hie1SJlrxC8hE+bZ9c/rQS+gqy7wOX3TwHlxQUnbKu0bMg==
+eslint-config-xo-typescript@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.10.1.tgz#fbba5ca8155b8e5b7cbd095bf7731b802980106e"
+  integrity sha512-EAmc1Zi+xDCH5JGe7d9YS2UpKZNQmXNTbWFRhmPRqdXFvS724BUmiaO6jcSo/wlaH5PrLgbZugT0piLFzK9dqg==
 
 eslint-config-xo@^0.26.0:
   version "0.26.0"


### PR DESCRIPTION
## Summary
`yarn test` failed when trying to release for #29

- Revert `eslint-config-xo-typescript` from `^0.11.0` back to `^0.10.1` (undoes the dependabot bump from #15)

0.11.0 enables `@typescript-eslint/semi` and `@typescript-eslint/func-call-spacing`, which only exist in `@typescript-eslint/eslint-plugin` v2+. xo `0.24` resolves plugin v1, so `xo` fails with `Definition for rule ... was not found` on every run — this is what aborted the `yarn release` for 5.8.0 at np's test step.

p.s. - Keeping `xo-typescript 0.11.0` would require bumping the repo's pinned `@typescript-eslint/eslint-plugin/parser` to v2 against xo 0.24's eslint-5-era stack, and v2's changed rule defaults would likely surface new lint errors needing code churn. Since this repo is largely in maintenance mode and the lint config has no effect on the published package, reverting to the known-good combination that shipped 5.7.0 is the pragmatic choice; a proper lint toolchain modernization can be its own chore PR if we ever need it.

## Test plan
- [x] `yarn test` (`xo && nyc ava`) passes locally with this change (was failing on `master`)