### PR TITLE
fix: pin `cheerio` to 1.0.0-rc.3 via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,5 +188,8 @@
       "test",
       "tools"
     ]
+  },
+  "resolutions": {
+    "cheerio": "1.0.0-rc.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,7 +4283,7 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-cheerio@1.0.0-rc.3:
+cheerio@1.0.0-rc.3, cheerio@^1.0.0-rc.3:
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
   integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==


### PR DESCRIPTION
## Summary
- Pin `cheerio` to `1.0.0-rc.3` with a yarn `resolutions` entry

The committed `yarn.lock` only contains an entry keyed `cheerio@1.0.0-rc.3`, but `enzyme@3.11.0` requests `cheerio@^1.0.0-rc.3`. With no matching lock key, fresh installs re-resolve that range from the registry and pick the current cheerio `1.2.0`, whose `exports` map blocks enzyme's `require('cheerio/lib/utils')` — every ava test file dies with an uncaught exception. This was the second blocker (after #30) aborting the 5.8.0 `yarn release` at np's test step.

## Test plan
- [x] `rm -rf node_modules && yarn install` resolves cheerio to `1.0.0-rc.3`
- [x] `yarn test` (`xo && nyc ava`) passes on a machine that previously failed